### PR TITLE
Remove reference to Front Door

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rsd-azure-front-door-waf
-Azure Front Door WAF for RSD
+Azure WAF for RSD
 
 [![Terraform CI](https://github.com/DFE-Digital/rsd-azure-front-door-waf/actions/workflows/continuous-integration-terraform.yml/badge.svg?branch=main)](https://github.com/DFE-Digital/rsd-azure-front-door-waf/actions/workflows/continuous-integration-terraform.yml/?branch=main)
 [![Tflint](https://github.com/DFE-Digital/rsd-azure-front-door-waf/actions/workflows/continuous-integration-tflint.yml/badge.svg?branch=main)](https://github.com/DFE-Digital/rsd-azure-front-door-waf/actions/workflows/continuous-integration-tflint.yml?branch=main)


### PR DESCRIPTION
- As the module now supports deploying front door or app gateway we should remove the specific reference from this repo