### PR TITLE
Stop using azapi to fetch container app information

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,12 @@ key                  = "terraform.tstate"
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 1.9.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.71.0 |
 
 ## Modules
@@ -66,7 +64,7 @@ key                  = "terraform.tstate"
 
 | Name | Type |
 |------|------|
-| [azapi_resource.container_apps](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource) | data source |
+| [azurerm_container_app.container_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_app) | data source |
 | [azurerm_linux_web_app.web_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_web_app) | data source |
 | [azurerm_resource_group.container_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_windows_web_app.web_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/windows_web_app) | data source |

--- a/data.tf
+++ b/data.tf
@@ -4,16 +4,11 @@ data "azurerm_resource_group" "container_apps" {
   name = each.value.resource_group
 }
 
-data "azapi_resource" "container_apps" {
+data "azurerm_container_app" "container_apps" {
   for_each = local.container_app_targets
 
-  name      = each.key
-  parent_id = data.azurerm_resource_group.container_apps[each.key].id
-  type      = "Microsoft.App/containerApps@2022-03-01"
-
-  response_export_values = [
-    "properties.configuration.ingress.fqdn",
-  ]
+  name                = each.key
+  resource_group_name = data.azurerm_resource_group.container_apps[each.key].name
 }
 
 data "azurerm_windows_web_app" "web_apps" {

--- a/locals.tf
+++ b/locals.tf
@@ -25,7 +25,7 @@ locals {
     {
       for container_app_target_name, container_app_target_value in local.container_app_targets : replace(container_app_target_name, local.environment, "") => merge(
         {
-          domain = jsondecode(data.azapi_resource.container_apps[container_app_target_name].output).properties.configuration.ingress.fqdn
+          domain = data.azurerm_container_app.container_apps[container_app_target_name].ingress[0].fqdn
         },
         container_app_target_value
       )

--- a/providers.tf
+++ b/providers.tf
@@ -2,5 +2,3 @@ provider "azurerm" {
   features {}
   skip_provider_registration = true
 }
-
-provider "azapi" {}

--- a/versions.tf
+++ b/versions.tf
@@ -5,9 +5,5 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.51.0"
     }
-    azapi = {
-      source  = "Azure/azapi"
-      version = ">= 1.1.0"
-    }
   }
 }


### PR DESCRIPTION
- We can use the azurerm_container_app resource instead and remove an extra dependancy on an Azure provider