### PR TITLE
Override the default Virtual Network address space

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ key                  = "terraform.tstate"
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
 | <a name="input_tfvars_access_ipv4"></a> [tfvars\_access\_ipv4](#input\_tfvars\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the tfvars Storage Account | `list(string)` | `[]` | no |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | Name of the TF Vars file | `string` | `"terraform.tfvars"` | no |
+| <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual Network address space CIDR | `string` | `"172.16.0.0/12"` | no |
 | <a name="input_waf_application"></a> [waf\_application](#input\_waf\_application) | Which product to apply the WAF to. Must be either CDN or AppGatewayV2 | `string` | n/a | yes |
 | <a name="input_waf_custom_rules"></a> [waf\_custom\_rules](#input\_waf\_custom\_rules) | Map of all Custom rules you want to apply to the WAF | <pre>map(object({<br/>    priority : number,<br/>    action : string<br/>    match_conditions : map(object({<br/>      match_variable : string,<br/>      match_values : optional(list(string), []),<br/>      operator : optional(string, "Any"),<br/>      selector : optional(string, ""),<br/>      negation_condition : optional(bool, false),<br/>    }))<br/>  }))</pre> | `{}` | no |
 | <a name="input_waf_mode"></a> [waf\_mode](#input\_waf\_mode) | WAF mode | `string` | n/a | yes |

--- a/locals.tf
+++ b/locals.tf
@@ -11,6 +11,8 @@ locals {
   existing_logic_app_workflow = var.existing_logic_app_workflow
   monitor_email_receivers     = var.monitor_email_receivers
 
+  virtual_network_address_space = var.virtual_network_address_space
+
   response_request_timeout = var.response_request_timeout
   container_app_targets    = var.container_app_targets
   web_app_service_targets  = var.web_app_service_targets

--- a/variables.tf
+++ b/variables.tf
@@ -220,3 +220,9 @@ variable "waf_tfvars_filename" {
   default     = "waf.tfvars"
   type        = string
 }
+
+variable "virtual_network_address_space" {
+  description = "Virtual Network address space CIDR"
+  type        = string
+  default     = "172.16.0.0/12"
+}

--- a/waf.tf
+++ b/waf.tf
@@ -7,6 +7,8 @@ module "waf" {
 
   response_request_timeout = local.response_request_timeout
 
+  virtual_network_address_space = local.virtual_network_address_space
+
   waf_targets = local.waf_targets
 
   enable_waf       = local.enable_waf


### PR DESCRIPTION
* We might want to set a different VNET space if we intend on using VNET peering